### PR TITLE
Fix teardown for terminal emacsclient

### DIFF
--- a/kkp.el
+++ b/kkp.el
@@ -613,12 +613,12 @@ Restore the original `local-function-key-map` for the first frame on TERMINAL’
 display by removing `kkp-alternatives-map` as a parent. Once done, the parameter
 `kkp-setup-function-keys` on TERMINAL is reset so that setup can be applied
 again later if needed."
-  (let ((frame (car (frames-on-display-list terminal))))
-    (when (terminal-parameter terminal 'kkp-setup-function-keys)
+  (when (terminal-parameter terminal 'kkp-setup-function-keys)
+    (dolist (frame (frames-on-display-list terminal))
       ;; Map certain keypad keys into ASCII characters that people usually expect.
       (with-selected-frame frame
-        (set-keymap-parent local-function-key-map (keymap-parent kkp-alternatives-map)))
-      (set-terminal-parameter terminal 'kkp-setup-function-keys nil))))
+        (set-keymap-parent local-function-key-map (keymap-parent kkp-alternatives-map))))
+    (set-terminal-parameter terminal 'kkp-setup-function-keys nil)))
 
 
 (defun kkp--terminal-teardown (terminal)
@@ -630,12 +630,12 @@ again later if needed."
     (kkp-teardown-function-keys terminal)
     (send-string-to-terminal (kkp--csi-escape "<u") terminal)
 
-    (normal-erase-is-backspace-mode (terminal-parameter terminal 'kkp--previous-normal-erase-is-backspace-val))
-
-    (with-selected-frame (car (frames-on-display-list terminal))
-      (dolist (prefix kkp--key-prefixes)
-        (compat-call define-key input-decode-map (kkp--csi-escape (string prefix)) nil t))
-      (run-hooks 'kkp-terminal-teardown-complete-hook)))
+    (dolist (frame (frames-on-display-list terminal))
+      (with-selected-frame frame
+        (normal-erase-is-backspace-mode (terminal-parameter terminal 'kkp--previous-normal-erase-is-backspace-val))
+        (dolist (prefix kkp--key-prefixes)
+          (compat-call define-key input-decode-map (kkp--csi-escape (string prefix)) nil t))
+        (run-hooks 'kkp-terminal-teardown-complete-hook))))
   ;; We want to remove the terminal anyway from the active terminal list
   ;; Either we just tore it down, or it is not live anyway and should not be on the list.
   (setq kkp--active-terminal-list (delete terminal kkp--active-terminal-list)))
@@ -674,14 +674,15 @@ does not have focus, as input from this terminal cannot be reliably read."
 
             (kkp-setup-function-keys terminal)
             (set-terminal-parameter terminal 'kkp--previous-normal-erase-is-backspace-val (terminal-parameter terminal 'normal-erase-is-backspace))
-            (normal-erase-is-backspace-mode 1)
 
-            ;; we register functions for each prefix to not interfere with e.g., M-[ I
-            (with-selected-frame (car (frames-on-display-list terminal))
-              (dolist (prefix kkp--key-prefixes)
-                (define-key input-decode-map (kkp--csi-escape (string prefix))
-                            (lambda (_prompt) (kkp--process-keys prefix))))
-              (run-hooks 'kkp-terminal-setup-complete-hook))))))))
+            (dolist (frame (frames-on-display-list terminal))
+              (with-selected-frame frame
+                (normal-erase-is-backspace-mode 1)
+                ;; we register functions for each prefix to not interfere with e.g., M-[ I
+                (dolist (prefix kkp--key-prefixes)
+                  (define-key input-decode-map (kkp--csi-escape (string prefix))
+                              (lambda (_prompt) (kkp--process-keys prefix))))
+                (run-hooks 'kkp-terminal-setup-complete-hook)))))))))
 
 
 (defun kkp--disable-in-active-terminals()


### PR DESCRIPTION
When a terminal emacsclient session exits, `frames-on-display-list` returns an empty list for that terminal. As a result, an exception is raised and the terminal is not torn down properly.

Additionally, running `normal-erase-is-backspace-mode` during teardown does not behave correctly when both GUI and TUI Emacs instances are running. These instances may have different states for this mode, and invoking it globally during terminal teardown can inadvertently affect other Emacs instances.

This change ensures that frames exist before attempting to process them, and limits `normal-erase-is-backspace-mode` to the frames associated with the terminal being torn down.

Fixes #23 

I haven't tested the change thoroughly but at the first glance it seems to fix mixing the terminal `emacsclient` with graphical `emacs` problem.