### PR TITLE
Update readme for global-kkp-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -42,9 +42,10 @@ Once that is done, this package can be installed.
 #+begin_src emacs-lisp
     (use-package kkp
       :ensure t
+      :hook (tty-setup . global-kkp-mode)
       :config
       ;; (setq kkp-alt-modifier 'alt) ;; use this if you want to map the Alt keyboard modifier to Alt in Emacs (and not to Meta)
-      (global-kkp-mode +1))
+      )
 #+end_src
 
 ** Usage


### PR DESCRIPTION
It probably makes sense to activate the mode only for TTY - don't need it in GUI Emacs.

`:config` always runs at package load time, before the autoloaded function body. So a user uncommenting that `setq` gets the value set before the mode activates.