### PR TITLE
Re-assert flags after legacy-keys pop for terminals without the flag stack

### DIFF
--- a/kkp-tests.el
+++ b/kkp-tests.el
@@ -159,26 +159,31 @@ engages."
      (nreverse out)))
 
 (ert-deftest kkp-test/legacy-keys--brackets-body-when-active ()
-  "`kkp-with-legacy-keys' pushes flags 0 and pops around the body."
+  "`kkp-with-legacy-keys' pushes flags 0, then pops and re-asserts the flags.
+The trailing set command covers terminals without the flag stack (e.g.
+zellij), where the pop alone would leave KKP disabled."
   (should (equal (kkp-test--capture-terminal-output
-                   (kkp-with-legacy-keys (ignore)))
+                  (kkp-with-legacy-keys (ignore)))
                  (list (kkp--csi-escape ">0u")
-                       (kkp--csi-escape "<u")))))
+                       (kkp--csi-escape "<u")
+                       (kkp--csi-escape "=1;1u")))))
 
 (ert-deftest kkp-test/legacy-keys--pops-on-non-local-exit ()
   "The encoding is restored even when the body signals."
   (should (equal (kkp-test--capture-terminal-output
-                   (ignore-errors (kkp-with-legacy-keys (error "boom"))))
+                  (ignore-errors (kkp-with-legacy-keys (error "boom"))))
                  (list (kkp--csi-escape ">0u")
-                       (kkp--csi-escape "<u")))))
+                       (kkp--csi-escape "<u")
+                       (kkp--csi-escape "=1;1u")))))
 
 (ert-deftest kkp-test/legacy-keys--nested-toggles-once ()
   "Nested `kkp-with-legacy-keys' forms toggle the terminal only once."
   (should (equal (kkp-test--capture-terminal-output
-                   (kkp-with-legacy-keys
-                     (kkp-with-legacy-keys (ignore))))
+                  (kkp-with-legacy-keys
+                    (kkp-with-legacy-keys (ignore))))
                  (list (kkp--csi-escape ">0u")
-                       (kkp--csi-escape "<u")))))
+                       (kkp--csi-escape "<u")
+                       (kkp--csi-escape "=1;1u")))))
 
 (ert-deftest kkp-test/legacy-keys--noop-when-inactive ()
   "No terminal writes happen when the terminal has no active `kkp--state'."
@@ -205,7 +210,9 @@ engages."
                  (lambda (s &optional _terminal) (push s out))))
         (kkp-with-legacy-keys (ignore)))
       (should (equal (nreverse out)
-                     (list (kkp--csi-escape ">0u") (kkp--csi-escape "<u")))))
+                     (list (kkp--csi-escape ">0u")
+                           (kkp--csi-escape "<u")
+                           (kkp--csi-escape "=1;1u")))))
     ;; This terminal already in legacy mode suppresses re-toggling.
     (let* ((out nil)
            (states (list (cons 'fake-term (kkp--make-state :enhancements 1
@@ -241,15 +248,36 @@ Writes are captured per terminal to check both the byte and the target."
                    (list (cons 'term-a (kkp--csi-escape ">0u"))
                          (cons 'term-b (kkp--csi-escape ">0u"))
                          (cons 'term-b (kkp--csi-escape "<u"))
-                         (cons 'term-a (kkp--csi-escape "<u")))))))
+                         (cons 'term-b (kkp--csi-escape "=1;1u"))
+                         (cons 'term-a (kkp--csi-escape "<u"))
+                         (cons 'term-a (kkp--csi-escape "=1;1u")))))))
+
+(ert-deftest kkp-test/legacy-keys--reasserts-terminal-flags ()
+  "The restore re-asserts the flags the terminal actually has active.
+Terminals without the flag stack (e.g. zellij) disable KKP on pop, so the
+set command must carry the real enhancement integer, not a constant."
+  (let ((out nil)
+        (states (list (cons 'fake-term (kkp--make-state :enhancements 5)))))
+    (cl-letf (((symbol-function 'kkp--selected-terminal) (lambda () 'fake-term))
+              ((symbol-function 'terminal-live-p) (lambda (_) t))
+              ((symbol-function 'kkp--terminal-state)
+               (lambda (term) (cdr (assq term states))))
+              ((symbol-function 'send-string-to-terminal)
+               (lambda (s &optional _terminal) (push s out))))
+      (kkp-with-legacy-keys (ignore)))
+    (should (equal (nreverse out)
+                   (list (kkp--csi-escape ">0u")
+                         (kkp--csi-escape "<u")
+                         (kkp--csi-escape "=5;1u"))))))
 
 (ert-deftest kkp-test/restore-legacy-keys--brackets-the-call ()
   "`kkp-restore-legacy-keys' (the public advice) brackets ORIG-FUN when active.
 It does not consult any defcustom; gating happens at the advice-install site."
   (should (equal (kkp-test--capture-terminal-output
-                   (kkp-restore-legacy-keys (lambda (&rest _) 0) "true"))
+                  (kkp-restore-legacy-keys (lambda (&rest _) 0) "true"))
                  (list (kkp--csi-escape ">0u")
-                       (kkp--csi-escape "<u")))))
+                       (kkp--csi-escape "<u")
+                       (kkp--csi-escape "=1;1u")))))
 
 (ert-deftest kkp-test/restore-legacy-keys--nested-advice-toggles-once ()
   "Stacking the advice (e.g. process-file delegating to call-process) toggles once.
@@ -258,9 +286,10 @@ The inner call must see the legacy switch already in effect and not re-toggle."
               (outer (&rest _)
                 (kkp-restore-legacy-keys #'inner "true")))
     (should (equal (kkp-test--capture-terminal-output
-                     (kkp-restore-legacy-keys #'outer "true"))
+                    (kkp-restore-legacy-keys #'outer "true"))
                    (list (kkp--csi-escape ">0u")
-                         (kkp--csi-escape "<u"))))))
+                         (kkp--csi-escape "<u")
+                         (kkp--csi-escape "=1;1u"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Key-translation regressions for closed issues

--- a/kkp.el
+++ b/kkp.el
@@ -397,8 +397,8 @@ to keep in sync."
       (define-key map [iso-lefttab] [backtab])
       (define-key map [S-iso-lefttab] [backtab]))
     (and (or (eq system-type 'windows-nt)
-	         (featurep 'ns))
-	     (define-key map [S-tab] [backtab]))
+	     (featurep 'ns))
+	 (define-key map [S-tab] [backtab]))
     map)
   "Keymap of possible alternative meanings for some keys.")
 
@@ -838,6 +838,24 @@ Restores the flags that were in effect before the matching push."
     (send-string-to-terminal (kkp--csi-escape "<u") terminal)
     (kkp--flush-standard-output)))
 
+(defun kkp--reassert-encoding-flags (terminal)
+  "Re-assert TERMINAL's active KKP flags with the set command (CSI = flags ; 1 u).
+Some terminals (e.g. zellij) implement the protocol without the flag
+stack: they treat the pop command as a plain disable instead of restoring
+the previously pushed flags, so `kkp--pop-encoding-flags' alone would
+leave them in legacy mode for good.  Re-sending the flags with the set
+command fixes those terminals, while on stack-compliant terminals it
+merely overwrites the current stack entry with the flags it already
+holds, so it is a no-op.  Does nothing when KKP is not active in
+TERMINAL."
+  (when (terminal-live-p terminal)
+    (let ((state (kkp--terminal-state terminal)))
+      (when (and state (kkp--state-enhancements state))
+        (send-string-to-terminal
+         (kkp--csi-escape (format "=%s;1u" (kkp--state-enhancements state)))
+         terminal)
+        (kkp--flush-standard-output)))))
+
 (defmacro kkp-with-legacy-keys (&rest body)
   "Run BODY with KKP key encoding temporarily disabled in the selected terminal.
 While BODY runs in a terminal where KKP is active, the terminal is asked to
@@ -845,6 +863,11 @@ revert to the legacy single-byte encoding of control keys, so that `C-g'
 arrives as the raw `quit-char' byte and can interrupt blocking subprocess
 calls such as a synchronous `call-process'.  The previous KKP flags are
 restored afterwards, even if BODY exits non-locally.
+
+The restore both pops the pushed entry and re-asserts the active flags
+with the set command, because terminals that implement the protocol
+without the flag stack (e.g. zellij) treat the pop as a plain disable
+\(see `kkp--reassert-encoding-flags').
 
 This is a no-op when KKP is not active in the selected terminal, and is
 not re-applied for nested forms."
@@ -861,7 +884,8 @@ not re-applied for nested forms."
          (unwind-protect
              (progn ,@body)
            (setf (kkp--state-legacy-active ,state) nil)
-           (kkp--pop-encoding-flags ,term))))))
+           (kkp--pop-encoding-flags ,term)
+           (kkp--reassert-encoding-flags ,term))))))
 
 (defun kkp-restore-legacy-keys (orig-fun &rest args)
   "Call ORIG-FUN with ARGS while KKP key encoding is temporarily disabled.


### PR DESCRIPTION
## Problem

`kkp-with-legacy-keys` restores KKP by popping the flags-0 entry it pushed (`CSI < u`), relying on the terminal to restore the previously pushed flags. Terminals that implement the kitty keyboard protocol **without the flag stack** treat the pop as a plain disable, so the restore never happens: after the first advised call (e.g. `kkp-restore-legacy-keys` around `envrc--export`), the terminal is left in legacy mode permanently while kkp's elisp state still believes KKP is active — KKP appears dead until re-enabled by hand.

zellij is the prominent case. From `zellij-server/src/panes/grid.rs` (0.43.1 and current main):

```rust
} else if c == 'u' && intermediates == &[b'>'] {
    // 0 disables, everything else enables.
    let count = next_param_or(0);
    if count > 0 { self.supports_kitty_keyboard_protocol = true; }
    else { self.supports_kitty_keyboard_protocol = false; }
} else if c == 'u' && intermediates == &[b'<'] {
    // Zellij only supports the first "progressive enhancement" layer
    self.supports_kitty_keyboard_protocol = false;
}
```

## Fix

Follow the pop with the protocol's *set* command (`CSI = flags ; 1 u`) carrying the terminal's active enhancement flags (new `kkp--reassert-encoding-flags`, called from the macro's cleanup):

- on stack-compliant terminals (kitty, ghostty, …) it is a no-op — it overwrites the top stack entry with the exact value the pop just restored, so stack depth stays balanced;
- on stack-less implementations like zellij it re-enables the protocol.

It reads the flags from the terminal's `kkp--state`, so it does nothing when KKP is not active.

## Testing

- Updated the legacy-keys write-sequence tests for the extra `=<flags>;1u` write and added a test pinning that the re-assert carries the terminal's real flag integer (`=5;1u` for flags 5).
- All 35 ERT tests pass in batch Emacs; byte-compilation is warning-neutral vs. main.
- The original symptom was hit in Emacs -nw inside zellij 0.43.1 with the advice attached to `envrc--export`: KKP dead after the first direnv call. The fix is verified against zellij's dispatch code above, by the test suite, and confirmed live: with this branch loaded, KKP chords keep working after `envrc--export` runs in Emacs -nw inside zellij 0.43.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKdAwbTvMZLXsbS5hXApVN

